### PR TITLE
only include dist, license and bower file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,12 +2,22 @@
   "name": "brim",
   "description": "View (minimal-ui) manager for iOS 8.",
   "version": "1.0.11",
+  "main": "brim",
   "keywords": [
     "minimal-ui",
     "ios",
     "fullscreen",
     "mobile",
     "viewport"
+  ],
+  "ignore": [
+    ".*",
+    "*.md",
+    "demo",
+    "src",
+    "tests",
+    "gulpfile.js",
+    "package.json"
   ],
   "license": "BSD-3-Clause",
   "authors": [


### PR DESCRIPTION
also added main entry

to avoid "invalid-meta" warning from bower
